### PR TITLE
DEVS-7752: Passing user's card billing address

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,14 @@ const wertWidget = new WertWidget(options);
     <td><code>+11014321111</code> / <code>11014321111</code></td>
     <td>User's phone number in the international format (E. 164 standard). Can be with or without +.</td>
   </tr>
+  <tr>
+    <td><strong>card_billing_address</strong></td>
+    <td>optional</td>
+    <td><i>String</i></td>
+    <td>-</td>
+    <td>See the <a href="#adding-card-billing-address">card billing address object structure</a></td>
+    <td>User's card billing address data</td>
+  </tr>
 </table>
 
 ### Appearance and restrictions
@@ -380,6 +388,19 @@ The wallet object structure:
 | name     | String | Example: `ETH`. See the [list of supported currencies](https://docs.wert.io/docs/supported-coins-and-blockchains).      |
 | network  | String | Example: `ethereum`. See the [list of supported currencies](https://docs.wert.io/docs/supported-coins-and-blockchains). |
 | address  | String | The wallet address. Non-valid addresses will be ignored.                                                                |
+
+#### Adding card billing address
+You can pass user's card billing address. This data will appear on the 'Enter your card details' or ‘Add a new card’ screen for users who have no added card yet. If a user already has a card, then when adding another card, the card billing address data is not prefilled.
+
+The card billing address object structure:
+
+| Property     | Type   | Description                                     |
+|--------------|--------|-------------------------------------------------|
+| country_code | String | card billing address alpha2 country code        |
+| city         | String | card billing address city                       |
+| state_code   | String | card billing address alpha2 state code (For US) |
+| post_code    | String | card billing address postal code                |
+| street       | String | card billing address street                     |
 
 ### Listeners
 

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ class WertWidget {
         return `${this.options.origin}/${this.options.partner_id}/widget${parametersString}`;
     }
     getParametersString() {
-        return Object.entries(Object.assign(Object.assign(Object.assign({}, this.options), { widget_layout_mode: this.widget_layout_mode }), (this.await_data && { await_data: this.await_data }))).reduce((accum, [key, value]) => {
+        return Object.entries(Object.assign(Object.assign(Object.assign({}, this.options), { card_billing_address: this.options.card_billing_address && JSON.stringify(this.options.card_billing_address), widget_layout_mode: this.widget_layout_mode }), (this.await_data && { await_data: this.await_data }))).reduce((accum, [key, value]) => {
             if (value === undefined || typeof value === 'object' || ['origin', 'partner_id'].includes(key)) {
                 return accum;
             }

--- a/index.ts
+++ b/index.ts
@@ -188,6 +188,7 @@ class WertWidget {
   private getParametersString(): string {
     return Object.entries({
       ...this.options,
+      card_billing_address: this.options.card_billing_address && JSON.stringify(this.options.card_billing_address),
       widget_layout_mode: this.widget_layout_mode,
       ...(this.await_data && { await_data: this.await_data })
     }).reduce(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "6.3.2",
+  "version": "6.4.0",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/types.d.ts
+++ b/types.d.ts
@@ -22,6 +22,7 @@ export type Options = {
     skip_init_navigation?: boolean;
     is_warranty_disabled?: boolean;
     is_crypto_hidden?: boolean;
+    card_billing_address?: CardBillingAddress;
 } & SCOptions & ColorsOptions & BordersOptions;
 type SCOptions = {
     sc_address?: string;
@@ -31,6 +32,13 @@ type SCOptions = {
 export interface ExtraOptions {
     item_info?: ItemInfo;
     wallets?: Wallet[];
+}
+interface CardBillingAddress {
+    country_code?: string;
+    city?: string;
+    state_code?: string;
+    post_code?: string;
+    street?: string;
 }
 interface ItemInfo {
     author_image_url?: string;

--- a/types.ts
+++ b/types.ts
@@ -23,6 +23,7 @@ export type Options = {
   skip_init_navigation?: boolean;
   is_warranty_disabled?: boolean;
   is_crypto_hidden?: boolean;
+  card_billing_address?: CardBillingAddress;
 } & SCOptions &
   ColorsOptions & BordersOptions;
 
@@ -37,6 +38,13 @@ export interface ExtraOptions {
   wallets?: Wallet[];
 }
 
+interface CardBillingAddress {
+  country_code?: string;
+  city?: string;
+  state_code?: string;
+  post_code?: string;
+  street?: string;
+}
 interface ItemInfo {
   author_image_url?: string;
   author?: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced an optional `card_billing_address` property for the WertWidget, allowing users to pre-fill their billing address when entering card details.
	- Added a new section in the documentation detailing how to use the card billing address feature.

- **Improvements**
	- Enhanced event listener management in the WertWidget for greater flexibility.
	- Updated the version of the package to 6.4.0. 

These updates aim to improve user experience and streamline the card payment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->