### PR TITLE
DEVS-7752: Passing user's card billing address

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,46 @@ const wertWidget = new WertWidget(options);
     <td><code>+11014321111</code> / <code>11014321111</code></td>
     <td>User's phone number in the international format (E. 164 standard). Can be with or without +.</td>
   </tr>
+  <tr>
+    <td><strong>card_country_code</strong></td>
+    <td>optional</td>
+    <td><i>String</i></td>
+    <td>-</td>
+    <td><code>US</code></td>
+    <td>Card billing address alpha2 country code.</td>
+  </tr>
+  <tr>
+    <td><strong>card_city</strong></td>
+    <td>optional</td>
+    <td><i>String</i></td>
+    <td>-</td>
+    <td><code>New York</code></td>
+    <td>Card billing address city.</td>
+  </tr>
+  <tr>
+    <td><strong>card_state_code</strong></td>
+    <td>optional</td>
+    <td><i>String</i></td>
+    <td>-</td>
+    <td><code>NY</code></td>
+    <td>Card billing address alpha2 state code (For US).</td>
+  </tr>
+  <tr>
+    <td><strong>card_post_code</strong></td>
+    <td>optional</td>
+    <td><i>String</i></td>
+    <td>-</td>
+    <td><code>12345</code></td>
+    <td>Card billing address postal code.</td>
+  </tr>
+  <tr>
+    <td><strong>card_street</strong></td>
+    <td>optional</td>
+    <td><i>String</i></td>
+    <td>-</td>
+    <td><code>### Church St</code></td>
+    <td>Card billing address street.</td>
+  </tr>
 </table>
 
 ### Appearance and restrictions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "6.3.2",
+  "version": "6.4.0",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/types.d.ts
+++ b/types.d.ts
@@ -22,7 +22,14 @@ export type Options = {
     skip_init_navigation?: boolean;
     is_warranty_disabled?: boolean;
     is_crypto_hidden?: boolean;
-} & SCOptions & ColorsOptions & BordersOptions;
+} & CardBillingAddressOptions & SCOptions & ColorsOptions & BordersOptions;
+type CardBillingAddressOptions = {
+    card_country_code?: string;
+    card_city?: string;
+    card_state_code?: string;
+    card_post_code?: string;
+    card_street?: string;
+};
 type SCOptions = {
     sc_address?: string;
     sc_input_data?: string;

--- a/types.ts
+++ b/types.ts
@@ -23,9 +23,16 @@ export type Options = {
   skip_init_navigation?: boolean;
   is_warranty_disabled?: boolean;
   is_crypto_hidden?: boolean;
-} & SCOptions &
+} & CardBillingAddressOptions & SCOptions &
   ColorsOptions & BordersOptions;
 
+type CardBillingAddressOptions = {
+  card_country_code?: string;
+  card_city?: string;
+  card_state_code?: string;
+  card_post_code?: string;
+  card_street?: string;
+}
 type SCOptions = {
   sc_address?: string;
   sc_input_data?: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added five optional properties for pre-filling user data related to card billing address: `card_country_code`, `card_city`, `card_state_code`, `card_post_code`, and `card_street`.
- **Documentation**
	- Enhanced the `README.md` to include descriptions and default values for the new optional properties.
- **Version Update**
	- Updated the project version from `6.3.2` to `6.4.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->