### PR TITLE
DEVS-8083: set attribute data-version for iframe

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 "use strict";
+const package_json_1 = require("./package.json");
 const externalStaticOrigin = 'https://javascript.wert.io';
 class WertWidget {
     constructor(options) {
@@ -65,6 +66,7 @@ class WertWidget {
         this.iframe.setAttribute('src', this.getEmbedUrl());
         this.iframe.setAttribute('allow', 'camera *; microphone *; payment');
         this.iframe.setAttribute('sandbox', 'allow-scripts allow-forms allow-popups allow-same-origin');
+        this.iframe.setAttribute('data-version', package_json_1.version);
         document.body.appendChild(this.iframe);
         this.widgetWindow = this.iframe.contentWindow;
         this.listenWidget();

--- a/index.ts
+++ b/index.ts
@@ -38,6 +38,7 @@ class WertWidget {
       'sandbox',
       'allow-scripts allow-forms allow-popups allow-same-origin'
     );
+    this.iframe.setAttribute('data-version', version);
 
     document.body.appendChild(this.iframe);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "6.7.0",
+  "version": "6.7.1",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/widget.test.js
+++ b/tests/widget.test.js
@@ -13,6 +13,7 @@ const {
   COMMODITIES,
   WALLETS,
 } = require('./mocks/options.js');
+const { version } = require('../package.json');
 
 let widget;
 let widgetLink;
@@ -69,7 +70,7 @@ describe('open', () => {
       document.body.children[0].contentWindow
     );
     expect(document.body.innerHTML).toBe(
-      `<iframe style="width: 100%; height: 100%; bottom: 0px; right: 0px; position: fixed; z-index: 10000;" src="${widgetLink}" allow="camera *; microphone *; payment" sandbox="allow-scripts allow-forms allow-popups allow-same-origin"></iframe>`
+      `<iframe style="width: 100%; height: 100%; bottom: 0px; right: 0px; position: fixed; z-index: 10000;" src="${widgetLink}" allow="camera *; microphone *; payment" sandbox="allow-scripts allow-forms allow-popups allow-same-origin" data-version="${version}"></iframe>`
     );
   });
   const SECONDS = 1000;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a `data-version` attribute to the iframe in the `WertWidget`, enhancing version traceability.
	- Updated the method signature of `removeEventListeners` for improved flexibility.

- **Bug Fixes**
	- Updated the package version from `6.7.0` to `6.7.1`.

- **Tests**
	- Updated tests to verify the inclusion of the new `data-version` attribute in the iframe's HTML structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->