### PR TITLE
HOTFIX: description update

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ const wertWidget = new WertWidget(options);
     <td><i>String</i></td>
     <td>-</td>
     <td><code>01K88HMYQAK47DSWB9RM3ZBNTP</code></td>
-    <td>User's ID. ?</td>
+    <td>Applicable for NFT checkout only. Upon loading the Widget with user_id, sms with OTP code is automatically sent to the corresponding phone number. A user lands straight to ‘Enter OTP’ code and proceeds to log in.</td>
   </tr>
   <tr>
     <td><strong>card_country_code</strong></td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "6.10.0",
+  "version": "6.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/widget-initializer",
-      "version": "6.10.0",
+      "version": "6.10.1",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.13.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "6.10.0",
+  "version": "6.10.1",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies `user_id` OTP flow for NFT checkout in README and bumps package version to 6.10.1.
> 
> - **Documentation**:
>   - Update `README.md` to clarify `user_id` behavior for NFT checkout: auto-sends SMS OTP and opens directly to OTP entry.
> - **Release/Versioning**:
>   - Bump `version` to `6.10.1` in `package.json` and `package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 937fa923acf856c35e98dfa03972545d2df72537. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->