### PR TITLE
MN-212: new init param hide_fee_breakdown to simplify processing fee description

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.1-beta.0",
+  "version": "7.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/widget-initializer",
-      "version": "7.0.1-beta.0",
+      "version": "7.0.1",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "7.13.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.0",
+  "version": "7.0.1-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/widget-initializer",
-      "version": "7.0.0",
+      "version": "7.0.1-beta.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "7.13.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.0",
+  "version": "7.0.1-beta.0",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.1-beta.0",
+  "version": "7.0.1",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/types.d.ts
+++ b/types.d.ts
@@ -30,6 +30,7 @@ export declare type Options = {
     payment_method?: string;
     payment_method_restriction?: boolean;
     display_currency?: string;
+    hide_fee_breakdown?: boolean;
 } & CardBillingAddressOptions & SCOptions;
 declare type CardBillingAddressOptions = {
     card_country_code?: string;

--- a/types.ts
+++ b/types.ts
@@ -31,6 +31,7 @@ export type Options = {
   payment_method?: string;
   payment_method_restriction?: boolean;
   display_currency?: string;
+  hide_fee_breakdown?: boolean;
 } & CardBillingAddressOptions & SCOptions;
 
 type CardBillingAddressOptions = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add new `hide_fee_breakdown` init option and bump package version to 7.0.1.
> 
> - **Types**:
>   - Extend `Options` with `hide_fee_breakdown` in `types.ts` and `types.d.ts`.
> - **Release**:
>   - Bump package version to `7.0.1` in `package.json` (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 820a4cae5718c3377c8c4a43371b927ed6f5b4b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->