### PR TITLE
MN-330: add external-order-id to PaymentStatusEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ const widget = new WertWidget({
     payment_id: String 
     order_id: String
     tx_id: String // if available
+    external_order_id: string;
   }
   ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/widget-initializer",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "7.13.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,4 @@
-export declare type Options = {
+export type Options = {
     partner_id: string;
     click_id?: string;
     origin?: string;
@@ -32,14 +32,14 @@ export declare type Options = {
     display_currency?: string;
     hide_fee_breakdown?: boolean;
 } & CardBillingAddressOptions & SCOptions;
-declare type CardBillingAddressOptions = {
+type CardBillingAddressOptions = {
     card_country_code?: string;
     card_city?: string;
     card_state_code?: string;
     card_post_code?: string;
     card_street?: string;
 };
-declare type SCOptions = {
+type SCOptions = {
     sc_address?: string;
     sc_input_data?: string;
     signature?: string;
@@ -62,18 +62,18 @@ interface Wallet {
     network: string;
     address: string;
 }
-declare type ThemeType = 'dark' | undefined;
-export declare type SetThemeParameters = {
+type ThemeType = 'dark' | undefined;
+export type SetThemeParameters = {
     theme?: ThemeType;
     brand_color?: string;
 };
-export declare type EventTypes = 'close' | 'error' | 'loaded' | 'payment-status' | 'position' | 'rate-update';
-export declare type InternalEventTypes = '3ds-start' | '3ds-end';
+export type EventTypes = 'close' | 'error' | 'loaded' | 'payment-status' | 'position' | 'rate-update';
+export type InternalEventTypes = '3ds-start' | '3ds-end';
 interface WidgetEvent<EventType extends EventTypes | InternalEventTypes> {
     type: EventType;
 }
-declare type CloseEvent = WidgetEvent<"close">;
-declare type LoadedEvent = WidgetEvent<"loaded">;
+type CloseEvent = WidgetEvent<"close">;
+type LoadedEvent = WidgetEvent<"loaded">;
 interface ErrorEvent extends WidgetEvent<"error"> {
     data: {
         name: string;
@@ -86,6 +86,7 @@ interface PaymentStatusEvent extends WidgetEvent<"payment-status"> {
         payment_id: string;
         order_id: string;
         tx_id?: string;
+        external_order_id: string;
     };
 }
 interface PositionEvent extends WidgetEvent<"position"> {
@@ -105,11 +106,11 @@ interface RateUpdateEvent extends WidgetEvent<"rate-update"> {
         currency_miner_fee: string;
     };
 }
-declare type Start3dsEvent = WidgetEvent<"3ds-start">;
-declare type End3dsEvent = WidgetEvent<"3ds-end">;
-export declare type WidgetEvents = CloseEvent | ErrorEvent | LoadedEvent | PaymentStatusEvent | PositionEvent | RateUpdateEvent;
-export declare type InternalWidgetEvents = Start3dsEvent | End3dsEvent;
-declare type EventListeners<Events extends {
+type Start3dsEvent = WidgetEvent<"3ds-start">;
+type End3dsEvent = WidgetEvent<"3ds-end">;
+export type WidgetEvents = CloseEvent | ErrorEvent | LoadedEvent | PaymentStatusEvent | PositionEvent | RateUpdateEvent;
+export type InternalWidgetEvents = Start3dsEvent | End3dsEvent;
+type EventListeners<Events extends {
     type: string;
     data?: Record<string, unknown>;
 }> = {

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,4 @@
-export type Options = {
+export declare type Options = {
     partner_id: string;
     click_id?: string;
     origin?: string;
@@ -32,14 +32,14 @@ export type Options = {
     display_currency?: string;
     hide_fee_breakdown?: boolean;
 } & CardBillingAddressOptions & SCOptions;
-type CardBillingAddressOptions = {
+declare type CardBillingAddressOptions = {
     card_country_code?: string;
     card_city?: string;
     card_state_code?: string;
     card_post_code?: string;
     card_street?: string;
 };
-type SCOptions = {
+declare type SCOptions = {
     sc_address?: string;
     sc_input_data?: string;
     signature?: string;
@@ -62,18 +62,18 @@ interface Wallet {
     network: string;
     address: string;
 }
-type ThemeType = 'dark' | undefined;
-export type SetThemeParameters = {
+declare type ThemeType = 'dark' | undefined;
+export declare type SetThemeParameters = {
     theme?: ThemeType;
     brand_color?: string;
 };
-export type EventTypes = 'close' | 'error' | 'loaded' | 'payment-status' | 'position' | 'rate-update';
-export type InternalEventTypes = '3ds-start' | '3ds-end';
+export declare type EventTypes = 'close' | 'error' | 'loaded' | 'payment-status' | 'position' | 'rate-update';
+export declare type InternalEventTypes = '3ds-start' | '3ds-end';
 interface WidgetEvent<EventType extends EventTypes | InternalEventTypes> {
     type: EventType;
 }
-type CloseEvent = WidgetEvent<"close">;
-type LoadedEvent = WidgetEvent<"loaded">;
+declare type CloseEvent = WidgetEvent<"close">;
+declare type LoadedEvent = WidgetEvent<"loaded">;
 interface ErrorEvent extends WidgetEvent<"error"> {
     data: {
         name: string;
@@ -106,11 +106,11 @@ interface RateUpdateEvent extends WidgetEvent<"rate-update"> {
         currency_miner_fee: string;
     };
 }
-type Start3dsEvent = WidgetEvent<"3ds-start">;
-type End3dsEvent = WidgetEvent<"3ds-end">;
-export type WidgetEvents = CloseEvent | ErrorEvent | LoadedEvent | PaymentStatusEvent | PositionEvent | RateUpdateEvent;
-export type InternalWidgetEvents = Start3dsEvent | End3dsEvent;
-type EventListeners<Events extends {
+declare type Start3dsEvent = WidgetEvent<"3ds-start">;
+declare type End3dsEvent = WidgetEvent<"3ds-end">;
+export declare type WidgetEvents = CloseEvent | ErrorEvent | LoadedEvent | PaymentStatusEvent | PositionEvent | RateUpdateEvent;
+export declare type InternalWidgetEvents = Start3dsEvent | End3dsEvent;
+declare type EventListeners<Events extends {
     type: string;
     data?: Record<string, unknown>;
 }> = {

--- a/types.ts
+++ b/types.ts
@@ -103,6 +103,7 @@ interface PaymentStatusEvent extends WidgetEvent<"payment-status"> {
     payment_id: string;
     order_id: string;
     tx_id?: string;
+    external_order_id: string;
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Type/documentation-only change plus a patch version bump; primary risk is minor downstream TypeScript breakage if consumers treat the event data as exact and don’t expect the new required field.
> 
> **Overview**
> Extends the `payment-status` widget event payload to include a new `external_order_id` field (updated in both TypeScript source types and generated `types.d.ts`).
> 
> Updates the README event docs to reflect the new field and bumps the package version from `7.0.1` to `7.0.2` (including lockfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b31c7c1e9e9448b0843863cb37c2dcae5a687c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->