### PR TITLE
MN-368 Fix explorer link

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class WertWidget {
         document.body.style.overflow = 'hidden';
         this.iframe.setAttribute('src', this.getEmbedUrl());
         this.iframe.setAttribute('allow', 'camera *; microphone *; payment');
-        this.iframe.setAttribute('sandbox', 'allow-scripts allow-forms allow-popups allow-same-origin');
+        this.iframe.setAttribute('sandbox', 'allow-scripts allow-forms allow-popups allow-same-origin allow-popups-to-escape-sandbox');
         this.iframe.setAttribute('data-version', package_json_1.version);
         document.body.appendChild(this.iframe);
         this.widgetWindow = this.iframe.contentWindow;

--- a/index.ts
+++ b/index.ts
@@ -36,7 +36,7 @@ class WertWidget {
     this.iframe.setAttribute('allow', 'camera *; microphone *; payment');
     this.iframe.setAttribute(
       'sandbox',
-      'allow-scripts allow-forms allow-popups allow-same-origin'
+      'allow-scripts allow-forms allow-popups allow-same-origin allow-popups-to-escape-sandbox'
     );
     this.iframe.setAttribute('data-version', version);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.3-beta.0",
+  "version": "7.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/widget-initializer",
-      "version": "7.0.3-beta.0",
+      "version": "7.0.3",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "7.13.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.2",
+  "version": "7.0.3-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/widget-initializer",
-      "version": "7.0.2",
+      "version": "7.0.3-beta.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "7.13.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.3-beta.0",
+  "version": "7.0.3",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.2",
+  "version": "7.0.3-beta.0",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/widget.test.js
+++ b/tests/widget.test.js
@@ -71,7 +71,7 @@ describe('open', () => {
       document.body.children[0].contentWindow
     );
     expect(document.body.innerHTML).toBe(
-      `<iframe style="width: 100%; height: 100%; bottom: 0px; right: 0px; position: fixed; z-index: 10000;" src="${widgetLink}" allow="camera *; microphone *; payment" sandbox="allow-scripts allow-forms allow-popups allow-same-origin" data-version="${version}"></iframe>`
+      `<iframe style="width: 100%; height: 100%; bottom: 0px; right: 0px; position: fixed; z-index: 10000;" src="${widgetLink}" allow="camera *; microphone *; payment" sandbox="allow-scripts allow-forms allow-popups allow-same-origin allow-popups-to-escape-sandbox" data-version="${version}"></iframe>`
     );
   });
   const SECONDS = 1000;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Relaxing iframe sandbox permissions affects every host integration; the change is narrow and targeted at popup behavior but still touches payment-widget embedding security boundaries.
> 
> **Overview**
> Fixes **blockchain explorer links** (and similar popups) from the embedded Wert widget by extending the iframe `sandbox` attribute with **`allow-popups-to-escape-sandbox`** in `WertWidget.open()` (`index.ts` / compiled `index.js`).
> 
> Previously, popups opened from the sandboxed iframe could stay constrained by the sandbox; this lets them run in a normal top-level browsing context so explorer URLs work as intended.
> 
> Bumps **`@wert-io/widget-initializer`** from **7.0.2 → 7.0.3** and updates the iframe HTML assertion in **`widget.test.js`** to match the new sandbox string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40e3befebdf47277d3eafffbdc63f5f83b5d801. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->