### PR TITLE
MN-352 MN-357 Addad is_auto_logout_on_order_complete_enabled and is_session_expire_on_email_mismatch fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,18 @@ const wertWidget = new WertWidget(options);
     <td><code>#FF0000</code></td>
     <td>Custom brand color that affects the following components: primary buttons, tooltips, steppers, tabs, checkboxes, toasts, pie countdowns.</td>
   </tr>
+  <tr>
+    <td><strong>is_auto_logout_on_order_complete_enabled</strong></td>
+    <td>optional</td>
+    <td><i>Boolean</i></td>
+    <td><code>undefined</code></td>
+    <td><code>true</code></td>
+    <td>
+      When <code>true</code>, the user's auth session is silently cleared as soon as an order reaches <code>success</code> status. The success screen remains visible; no redirect occurs. Any subsequent navigation to an auth-protected route will resolve to the login page.
+      <br/><br/>
+      <i>- Please check the <a href="#boolean-usage">boolean usage note</a></i>
+    </td>
+  </tr>
 </table>
 
 ### Extra object structure

--- a/README.md
+++ b/README.md
@@ -406,6 +406,18 @@ const wertWidget = new WertWidget(options);
       <i>- Please check the <a href="#boolean-usage">boolean usage note</a></i>
     </td>
   </tr>
+  <tr>
+    <td><strong>is_session_expire_on_email_mismatch</strong></td>
+    <td>optional</td>
+    <td><i>Boolean</i></td>
+    <td><code>undefined</code></td>
+    <td><code>true</code></td>
+    <td>
+      When <code>true</code>, the user's auth session is discarded if the <code>email</code> query parameter does not match the email of the currently logged-in user (comparison is case-insensitive). The user is redirected to the login page; no session data is preserved.
+      <br/><br/>
+      <i>- Please check the <a href="#boolean-usage">boolean usage note</a></i>
+    </td>
+  </tr>
 </table>
 
 ### Extra object structure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.3",
+  "version": "7.0.4-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/widget-initializer",
-      "version": "7.0.3",
+      "version": "7.0.4-beta.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "7.13.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.4-beta.0",
+  "version": "7.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/widget-initializer",
-      "version": "7.0.4-beta.0",
+      "version": "7.0.4",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "7.13.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.3",
+  "version": "7.0.4-beta.0",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.4-beta.0",
+  "version": "7.0.4",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/types.ts
+++ b/types.ts
@@ -33,6 +33,7 @@ export type Options = {
   display_currency?: string;
   hide_fee_breakdown?: boolean;
   is_auto_logout_on_order_complete_enabled?: boolean;
+  is_session_expire_on_email_mismatch?: boolean;
 } & CardBillingAddressOptions & SCOptions;
 
 type CardBillingAddressOptions = {

--- a/types.ts
+++ b/types.ts
@@ -32,6 +32,7 @@ export type Options = {
   payment_method_restriction?: boolean;
   display_currency?: string;
   hide_fee_breakdown?: boolean;
+  is_auto_logout_on_order_complete_enabled?: boolean;
 } & CardBillingAddressOptions & SCOptions;
 
 type CardBillingAddressOptions = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Surface-area is optional typed flags and documentation plus a patch version bump; session behavior is enforced in the remote widget, not in this package’s runtime code.
> 
> **Overview**
> Partners can pass two new optional booleans on `WertWidget` options: **`is_auto_logout_on_order_complete_enabled`** clears the auth session when an order hits `success` (success UI stays; later protected routes go to login), and **`is_session_expire_on_email_mismatch`** drops the session and sends the user to login when the `email` query param does not match the logged-in user (case-insensitive).
> 
> The fields are added to the public **`Options`** type in `types.ts` and documented in the README **Appearance and restrictions** table (with the standard boolean-usage note). Package version is bumped to **7.0.4** in `package.json` and `package-lock.json`. No initializer logic changes—the existing embed URL builder already forwards scalar options to the widget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb231e5a5e29950f3932b85ed6e439ff824dc2e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->