### PR TITLE
DEVS-10056 CashApp app is not opening on mobile from modal window

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class WertWidget {
         document.body.style.overflow = 'hidden';
         this.iframe.setAttribute('src', this.getEmbedUrl());
         this.iframe.setAttribute('allow', 'camera *; microphone *; payment');
-        this.iframe.setAttribute('sandbox', 'allow-scripts allow-forms allow-popups allow-same-origin allow-popups-to-escape-sandbox');
+        this.iframe.setAttribute('sandbox', 'allow-scripts allow-forms allow-popups allow-same-origin allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation');
         this.iframe.setAttribute('data-version', package_json_1.version);
         document.body.appendChild(this.iframe);
         this.widgetWindow = this.iframe.contentWindow;

--- a/index.ts
+++ b/index.ts
@@ -36,7 +36,7 @@ class WertWidget {
     this.iframe.setAttribute('allow', 'camera *; microphone *; payment');
     this.iframe.setAttribute(
       'sandbox',
-      'allow-scripts allow-forms allow-popups allow-same-origin allow-popups-to-escape-sandbox'
+      'allow-scripts allow-forms allow-popups allow-same-origin allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation'
     );
     this.iframe.setAttribute('data-version', version);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.4",
+  "version": "7.0.5-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/widget-initializer",
-      "version": "7.0.4",
+      "version": "7.0.5-beta.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "7.13.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.5-beta.0",
+  "version": "7.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/widget-initializer",
-      "version": "7.0.5-beta.0",
+      "version": "7.0.5",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "7.13.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.5-beta.0",
+  "version": "7.0.5",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.4",
+  "version": "7.0.5-beta.0",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/widget.test.js
+++ b/tests/widget.test.js
@@ -71,7 +71,7 @@ describe('open', () => {
       document.body.children[0].contentWindow
     );
     expect(document.body.innerHTML).toBe(
-      `<iframe style="width: 100%; height: 100%; bottom: 0px; right: 0px; position: fixed; z-index: 10000;" src="${widgetLink}" allow="camera *; microphone *; payment" sandbox="allow-scripts allow-forms allow-popups allow-same-origin allow-popups-to-escape-sandbox" data-version="${version}"></iframe>`
+      `<iframe style="width: 100%; height: 100%; bottom: 0px; right: 0px; position: fixed; z-index: 10000;" src="${widgetLink}" allow="camera *; microphone *; payment" sandbox="allow-scripts allow-forms allow-popups allow-same-origin allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation" data-version="${version}"></iframe>`
     );
   });
   const SECONDS = 1000;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Sandbox is slightly relaxed but only for user-activated top navigation, which is the intended fix for wallet deep links; no auth or payment logic changes.
> 
> **Overview**
> Fixes **Cash App not opening on mobile** when users trigger it from inside the Wert modal by extending the widget iframe `sandbox` with **`allow-top-navigation-by-user-activation`**.
> 
> That token only permits top-level navigation (e.g. app/deep links) after a **user gesture**, without enabling unrestricted `allow-top-navigation`. Changes are mirrored in **`index.ts`** / **`index.js`** and the iframe HTML assertion in **`widget.test.js`**. Package version is bumped to **7.0.5**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99781538ac669cd2b06eb5feec4c03957a877b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->