### PR TITLE
MN-408 Extending the Payment method restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ const wertWidget = new WertWidget(options);
   <tr>
     <td><strong>payment_method</strong></td>
     <td>optional</td>
-    <td><i>String</i></td>
+    <td><i>String | String[]</i></td>
     <td><code>card</code></td>
-    <td><code>card</code><br/><code>apple-pay</code><br/><code>google-pay</code></td>
-    <td>If set, this method will be <b>pre-selected and shown first</b> in the list of available methods. Other methods will still be available unless <code>payment_method_restriction</code> is used.</td>
+    <td><code>card</code><br/><code>apple-pay</code><br/><code>google-pay</code><br/><code>cash-app</code><br/><code>sepa</code><br/><code>blik</code><br/><code>['apple-pay', 'cash-app']</code></td>
+    <td>One method (as a plain string, e.g. <code>'card'</code>) or several methods (as an array, e.g. <code>['apple-pay', 'cash-app']</code>) to pre-select and show first, in the given order. Other methods will still be available unless <code>payment_method_restriction</code> is used. Passing a single string keeps working exactly as before — passing an array is fully backward-compatible and not required.</td>
   </tr>
   <tr>
     <td><strong>payment_method_restriction</strong></td>
@@ -119,7 +119,7 @@ const wertWidget = new WertWidget(options);
     <td><i>Boolean</i></td>
     <td><code>false</code></td>
     <td><code>true</code></td>
-    <td>If <code>true</code>, the widget will show <b>only</b> the method specified in <code>payment_method</code> (if it’s available). If that method isn’t available, the widget will fall back to showing all available methods.</td>
+    <td>If <code>true</code>, the widget will show <b>only</b> the method(s) specified in <code>payment_method</code>, in the given order (any methods that aren’t available are ignored). If none of the specified methods are available, the widget will fall back to showing all available methods.</td>
   </tr>
 </table>
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,15 @@
 "use strict";
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
 const package_json_1 = require("./package.json");
 const externalStaticOrigin = 'https://javascript.wert.io';
 class WertWidget {
@@ -146,7 +157,11 @@ class WertWidget {
         return `${this.options.origin}/${this.options.partner_id}/widget${parametersString}`;
     }
     getParametersString() {
-        return Object.entries(Object.assign(Object.assign(Object.assign({}, this.options), { widget_layout_mode: this.widget_layout_mode }), (this.await_data && { await_data: this.await_data }))).reduce((accum, [key, value]) => {
+        const _a = this.options, { payment_method } = _a, restOptions = __rest(_a, ["payment_method"]);
+        const normalizedPaymentMethod = Array.isArray(payment_method)
+            ? JSON.stringify(payment_method)
+            : payment_method;
+        return Object.entries(Object.assign(Object.assign(Object.assign({}, restOptions), { payment_method: normalizedPaymentMethod, widget_layout_mode: this.widget_layout_mode }), (this.await_data && { await_data: this.await_data }))).reduce((accum, [key, value]) => {
             if (value === undefined || typeof value === 'object' || ['origin', 'partner_id'].includes(key)) {
                 return accum;
             }

--- a/index.ts
+++ b/index.ts
@@ -188,8 +188,14 @@ class WertWidget {
   }
 
   private getParametersString(): string {
+    const { payment_method, ...restOptions } = this.options;
+    const normalizedPaymentMethod = Array.isArray(payment_method)
+      ? JSON.stringify(payment_method)
+      : payment_method;
+
     return Object.entries({
-      ...this.options,
+      ...restOptions,
+      payment_method: normalizedPaymentMethod,
       widget_layout_mode: this.widget_layout_mode,
       ...(this.await_data && { await_data: this.await_data })
     }).reduce(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.5",
+  "version": "7.0.6-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wert-io/widget-initializer",
-      "version": "7.0.5",
+      "version": "7.0.6-beta.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "7.13.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wert-io/widget-initializer",
-  "version": "7.0.5",
+  "version": "7.0.6-beta.0",
   "description": "WertWidget helper",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests/mocks/options.js
+++ b/tests/mocks/options.js
@@ -28,6 +28,7 @@ const MINIMUM_OPTIONS_FILLED = {
 
 const COMMODITIES = [{"commodity":"GHST","network":"mumbai"}, {"commodity":"STX","network":"testnet"}];
 const CURRENCIES = ["USD"];
+const PAYMENT_METHODS = ["apple-pay", "cashapp"];
 
 const WALLETS = [
   {
@@ -42,5 +43,6 @@ module.exports = {
   MINIMUM_OPTIONS_FILLED,
   COMMODITIES,
   CURRENCIES,
+  PAYMENT_METHODS,
   WALLETS
 };

--- a/tests/widget.test.js
+++ b/tests/widget.test.js
@@ -12,6 +12,7 @@ const {
   MINIMUM_OPTIONS_FILLED,
   COMMODITIES,
   CURRENCIES,
+  PAYMENT_METHODS,
   WALLETS,
 } = require('./mocks/options.js');
 const { version } = require('../package.json');
@@ -219,6 +220,29 @@ describe('getEmbedUrl & getParametersString', () => {
       && JSON.stringify(CURRENCIES) === JSON.stringify(currenciesFromUrl);
 
     expect(arraysAreEqual).toBe(true);
+  });
+  test('payment_method as an array should be JSON-serialized in the URL query', () => {
+    widget = new WertWidget({
+      ...MINIMUM_OPTIONS_FILLED,
+      payment_method: PAYMENT_METHODS,
+    });
+    widgetLink = widget.getEmbedUrl();
+
+    const searchParams = new URLSearchParams(widgetLink.split('?')[1]);
+    const paymentMethodFromUrl = JSON.parse(searchParams.get('payment_method'));
+
+    expect(paymentMethodFromUrl).toEqual(PAYMENT_METHODS);
+  });
+  test('payment_method as a plain string should still be present in the URL query', () => {
+    widget = new WertWidget({
+      ...MINIMUM_OPTIONS_FILLED,
+      payment_method: 'card',
+    });
+    widgetLink = widget.getEmbedUrl();
+
+    const searchParams = new URLSearchParams(widgetLink.split('?')[1]);
+
+    expect(searchParams.get('payment_method')).toBe('card');
   });
 });
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -27,10 +27,12 @@ export declare type Options = {
     is_crypto_hidden?: boolean;
     session_id?: string;
     terms_on_payment?: boolean;
-    payment_method?: string;
+    payment_method?: string | string[];
     payment_method_restriction?: boolean;
     display_currency?: string;
     hide_fee_breakdown?: boolean;
+    is_auto_logout_on_order_complete_enabled?: boolean;
+    is_session_expire_on_email_mismatch?: boolean;
 } & CardBillingAddressOptions & SCOptions;
 declare type CardBillingAddressOptions = {
     card_country_code?: string;

--- a/types.ts
+++ b/types.ts
@@ -28,7 +28,7 @@ export type Options = {
   is_crypto_hidden?: boolean;
   session_id?: string;
   terms_on_payment?: boolean;
-  payment_method?: string;
+  payment_method?: string | string[];
   payment_method_restriction?: boolean;
   display_currency?: string;
   hide_fee_breakdown?: boolean;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Backward-compatible option typing and query serialization with focused tests; no auth or payment-processing logic changes in this package.
> 
> **Overview**
> **`payment_method`** can now be a **string or string array**, so partners can pre-select and order several methods (e.g. `['apple-pay', 'cash-app']`). Single-string usage is unchanged.
> 
> **URL building** in `getParametersString` JSON-stringifies array values before query encoding so they are no longer dropped by the existing “skip object values” rule; plain strings still pass through as before.
> 
> **Docs** update `payment_method` / **`payment_method_restriction`** to describe multi-method ordering, more method examples, and restriction behavior when none of the listed methods are available. **Tests** cover array vs string serialization. Version bumped to **7.0.6-beta.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3f645fc68ca6753bce74c0b76616a5af588a271. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->