### PR TITLE
MN-409 ESM Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [WertWidget initializer](#wertwidget-initializer)
   - [Installation](#installation)
   - [Usage](#usage)
+  - [Using without npm (browser `<script>` build)](#using-without-npm-browser-script-build)
   - [Options](#options)
     - [General options](#general-options)
     - [Smart contract options](#smart-contract-options)
@@ -43,6 +44,33 @@ First of all, you need to create a widget class:
 ```
 const wertWidget = new WertWidget(options);
 ```
+
+## Using without npm (browser `<script>` build)
+
+If your app doesn't use npm/a bundler, you can load a pre-built version of this package straight from `https://javascript.wert.io/`. Two formats are published for every version, replace `VERSION` below with the package version you need (e.g. `7.0.6`):
+
+- **IIFE** (`wert-VERSION.js`) — a classic script that exposes the widget as `window.WertWidget`:
+
+  ```html
+  <script src="https://javascript.wert.io/wert-VERSION.js"></script>
+  <script>
+    const wertWidget = new window.WertWidget(options);
+    wertWidget.open();
+  </script>
+  ```
+
+- **ES module** (`wert-VERSION.esm.js`) — can be imported directly in a `<script type="module">` or from your own JS module:
+
+  ```html
+  <script type="module">
+    import WertWidget from 'https://javascript.wert.io/wert-VERSION.esm.js';
+
+    const wertWidget = new WertWidget(options);
+    wertWidget.open();
+  </script>
+  ```
+
+Both files are built from this package via `npm run build-script` (see `rollup.config.js`) and published to GitHub Pages on release, so they always match the corresponding npm version.
 
 ## Options
 

--- a/browser-script-entry-esm.js
+++ b/browser-script-entry-esm.js
@@ -1,0 +1,3 @@
+import WertWidget from './index.js';
+
+export default WertWidget;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,28 +5,40 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 
 import { version } from './package.json';
 
-export default {
-  input: 'browser-script-entry.js',
-  output: {
-    file: `dist/wert-${version}.js`,
-    format: 'iife',
-  },
-  plugins: [
-    nodeResolve(),
-    commonjs(),
-    json(),
-    babel({
-      babelrc: false,
-      presets: [
-        [
-          '@babel/preset-env',
-          {
-            targets: 'defaults, ie >= 11',
-            // debug: true,
-          },
-        ],
+const createPlugins = () => [
+  nodeResolve(),
+  commonjs(),
+  json(),
+  babel({
+    babelrc: false,
+    presets: [
+      [
+        '@babel/preset-env',
+        {
+          targets: 'defaults, ie >= 11',
+          // debug: true,
+        },
       ],
-      babelHelpers: 'bundled',
-    }),
-  ],
-};
+    ],
+    babelHelpers: 'bundled',
+  }),
+];
+
+export default [
+  {
+    input: 'browser-script-entry.js',
+    output: {
+      file: `dist/wert-${version}.js`,
+      format: 'iife',
+    },
+    plugins: createPlugins(),
+  },
+  {
+    input: 'browser-script-entry-esm.js',
+    output: {
+      file: `dist/wert-${version}.esm.js`,
+      format: 'es',
+    },
+    plugins: createPlugins(),
+  },
+];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build and packaging only; the IIFE artifact and plugin stack are preserved, with an additive ESM output.
> 
> **Overview**
> Adds a second Rollup build so consumers can import the widget as an ES module, not only via the existing IIFE script tag.
> 
> A new **`browser-script-entry-esm.js`** entry default-exports `WertWidget` from `./index.js` (mirroring the IIFE entry’s widget, but with `import`/`export` instead of `require` and `window`). **`rollup.config.js`** now exports an array of two configs: the original IIFE output to `dist/wert-${version}.js` is unchanged, and a new build writes **`dist/wert-${version}.esm.js`** with `format: 'es'`. Shared Babel/resolve/CommonJS/JSON plugins are extracted into **`createPlugins()`** so both bundles use the same toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c0fa52613584d97bb8d786d3f17889e27ec9ced. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->